### PR TITLE
Double space fix

### DIFF
--- a/ruby-electric.el
+++ b/ruby-electric.el
@@ -389,6 +389,7 @@ enabled."
              (insert " "))
          (insert " "))
        (insert " ")
+       (backward-char 1)
        (and region-beginning
             (forward-char 1)))))
     ((ruby-electric-string-at-point-p)


### PR DESCRIPTION
This PR fixes a curly bracket electric behavior.
When I type "{" it expands to "{  |}" where "|" is a cursor position. It looks wrong, so I suggest to change it to "{ | }" (the cursor stays in the middle, not at the end).